### PR TITLE
Abstract Principle Implementation

### DIFF
--- a/OOP-Example.csproj
+++ b/OOP-Example.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿    <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,9 +7,5 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
-
-  <ItemGroup>
-    <Compile Include="C:\ES-edu\utbildning\OOP\vecka1\OveningInlämningExtented\Program.cs" Link="Program.cs" />
-  </ItemGroup>
 
 </Project>

--- a/OOP-Example.csproj
+++ b/OOP-Example.csproj
@@ -8,4 +8,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <Compile Include="C:\ES-edu\utbildning\OOP\vecka1\OveningInlämningExtented\Program.cs" Link="Program.cs" />
+  </ItemGroup>
+
 </Project>

--- a/Program.cs
+++ b/Program.cs
@@ -4,17 +4,87 @@
     {
         static void Main(string[] args)
         {
-            // Create an instance of Shape
-            Shape shape1 = new Shape();
-            shape1.Name = "Circle";
-            shape1.IsFilled = false;
-            shape1.GetInfo(); // Output: This is a Circle and it Not filled.
+            //// Create a Shape reference pointing to a Circle object 
+            //// Abstraction and Polymorphism in action
+            //Shape circle = new Circle
+            //{
+            //    Name = "Circle",
+            //    IsFilled = true,
+            //    Radius = 5.0
+            //};
+            ////circle.GetInfo(); // Display shape details
+            ////circle.DisplayArea(); // Show calculated area
 
-            // create another instance of Shape
-            Shape shape2 = new Shape();
-            shape2.Name = "Rectangle";
-            shape2.IsFilled = true;
-            shape2.GetInfo(); // Output: This is a Rectangle and it is Filled.
+            //// Create a shape reference pointing to a Rectangle object
+            //Shape rectangle = new Rectangle
+            //{
+            //    Name = "Rectangle",
+            //    IsFilled = false,
+            //    Length = 4.0,
+            //    Width = 6.0
+            //};
+
+            //// Create a shape reference pointing to a Triangle object
+            //Shape triangle = new Triangle
+            //{
+            //    Name = "Triangle",
+            //    IsFilled = true,
+            //    Base = 3.0,
+            //    Height = 4.0
+            //};
+            //// create an array of shapes to demonstrate polymorphism
+            //var shapes = new Shape[] { circle, rectangle, triangle };
+
+            //// loop through the array and display info and area for each shape
+            //foreach (Shape shape in shapes)
+            //{
+            //    Console.WriteLine("\n--- New Shape Object ---\n");
+            //    shape.GetInfo();
+            //    shape.DisplayArea();
+            //}
+
+            // create a list of shapes to demonstrate polymorphism
+            List<Shape> shapes = new List<Shape>();
+
+            // add different shapes to the list
+            shapes.Add(new Circle
+            {
+                Name = "Circle",
+                IsFilled = true,
+                Radius = 0.1 * Math.PI
+            });
+            shapes.Add(new Rectangle
+            {
+                Name = "Rectangle",
+                IsFilled = false,
+                Length = 1.0,
+                Width = 2.0
+            });
+            shapes.Add(new Triangle
+            {
+                Name = "Triangle",
+                IsFilled = true,
+                Base = 1.0,
+                Height = 2.0
+            });
+
+            // add 10 random circles to the list
+            Random rand = new Random();
+            for (int i = 0; i < 10; i++)
+            {
+                shapes.Add(new Circle
+                {
+                    Name = $"Circle {i + 1}",
+                    IsFilled = rand.Next(2) == 0,
+                    Radius = rand.NextDouble() *10
+                });
+            }
+            foreach (Shape shape in shapes)
+            {
+                Console.WriteLine("--- New Shape Object ---");
+                shape.GetInfo();
+                shape.DisplayArea();
+            }
 
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -4,88 +4,44 @@
     {
         static void Main(string[] args)
         {
-            //// Create a Shape reference pointing to a Circle object 
-            //// Abstraction and Polymorphism in action
-            //Shape circle = new Circle
-            //{
-            //    Name = "Circle",
-            //    IsFilled = true,
-            //    Radius = 5.0
-            //};
-            ////circle.GetInfo(); // Display shape details
-            ////circle.DisplayArea(); // Show calculated area
-
-            //// Create a shape reference pointing to a Rectangle object
-            //Shape rectangle = new Rectangle
-            //{
-            //    Name = "Rectangle",
-            //    IsFilled = false,
-            //    Length = 4.0,
-            //    Width = 6.0
-            //};
-
-            //// Create a shape reference pointing to a Triangle object
-            //Shape triangle = new Triangle
-            //{
-            //    Name = "Triangle",
-            //    IsFilled = true,
-            //    Base = 3.0,
-            //    Height = 4.0
-            //};
-            //// create an array of shapes to demonstrate polymorphism
-            //var shapes = new Shape[] { circle, rectangle, triangle };
-
-            //// loop through the array and display info and area for each shape
-            //foreach (Shape shape in shapes)
-            //{
-            //    Console.WriteLine("\n--- New Shape Object ---\n");
-            //    shape.GetInfo();
-            //    shape.DisplayArea();
-            //}
-
-            // create a list of shapes to demonstrate polymorphism
-            List<Shape> shapes = new List<Shape>();
-
-            // add different shapes to the list
-            shapes.Add(new Circle
+            // Create a Shape reference pointing to a Circle object 
+            // Abstraction and Polymorphism in action
+            Shape circle = new Circle
             {
                 Name = "Circle",
                 IsFilled = true,
-                Radius = 0.1 * Math.PI
-            });
-            shapes.Add(new Rectangle
+                Radius = 5.0
+            };
+            //circle.GetInfo(); // Display shape details
+            //circle.DisplayArea(); // Show calculated area
+
+            // Create a shape reference pointing to a Rectangle object
+            Shape rectangle = new Rectangle
             {
                 Name = "Rectangle",
                 IsFilled = false,
-                Length = 1.0,
-                Width = 2.0
-            });
-            shapes.Add(new Triangle
+                Length = 4.0,
+                Width = 6.0
+            };
+
+            // Create a shape reference pointing to a Triangle object
+            Shape triangle = new Triangle
             {
                 Name = "Triangle",
                 IsFilled = true,
-                Base = 1.0,
-                Height = 2.0
-            });
+                Base = 3.0,
+                Height = 4.0
+            };
+            // create an array of shapes to demonstrate polymorphism
+            var shapes = new Shape[] { circle, rectangle, triangle };
 
-            // add 10 random circles to the list
-            Random rand = new Random();
-            for (int i = 0; i < 10; i++)
-            {
-                shapes.Add(new Circle
-                {
-                    Name = $"Circle {i + 1}",
-                    IsFilled = rand.Next(2) == 0,
-                    Radius = rand.NextDouble() *10
-                });
-            }
+            // loop through the array and display info and area for each shape
             foreach (Shape shape in shapes)
             {
-                Console.WriteLine("--- New Shape Object ---");
+                Console.WriteLine("\n--- New Shape Object ---\n");
                 shape.GetInfo();
                 shape.DisplayArea();
             }
-
         }
     }
 }

--- a/Shape.cs
+++ b/Shape.cs
@@ -1,16 +1,70 @@
 ﻿namespace OOP_Example
 {
-    public class Shape
+    //Abstraction of a Shape
+    //    Define abstract class Shape
+    //    Property: Name
+    //    Property: IsFilled
+    //    Abstract Method: GetArea()
+    //    Virtual Method: DisplayArea()
+    //    Method: GetInfo()
+
+    //Define class Circle that inherits from Shape
+    //    Property: Radius
+    //    Override Method: GetArea()
+    //    Override Method: DisplayArea()
+
+    public abstract class Shape
     {
         // Properties
         public string Name { get; set; }
         public bool IsFilled { get; set; }
 
+        // Abstract method to be implemented by derived classes, no body/implementation here for abstract methods
+        public abstract double GetArea();
+        // public abstract void DisplayArea();
+
+        public virtual void DisplayArea()
+        {
+            Console.WriteLine($"Area: {Math.Round(GetArea(), 1)}");
+        }
+
         // Methods
         public void GetInfo()
         {
             string fillStatus = IsFilled ? "Filled" : "Not filled"; //Derived value
-            Console.WriteLine($"This is a {Name} and it is {fillStatus}.");
+            Console.WriteLine($"Object: {Name}, Status: {fillStatus}.");
         }
+    }
+    public class Circle : Shape
+    {
+        // Property specific to Circle
+        public double Radius { get; set; }
+
+        // Override the abstract method to provide implementation
+        public override double GetArea()
+        {
+            return Math.PI * Radius * Radius;
+        }
+    }
+    public class Rectangle : Shape
+    {
+        public double Length { get; set; }
+        public double Width { get; set; }
+
+        public override double GetArea()
+        {
+            return Length * Width;
+        }
+
+    }
+    public class Triangle : Shape
+    {
+        public double Base { get; set; }
+        public double Height { get; set; }
+        public override double GetArea()
+        {
+            return 0.5 * Base * Height;
+        }
+
     }
 }

--- a/Shape.cs
+++ b/Shape.cs
@@ -1,28 +1,19 @@
 ﻿namespace OOP_Example
 {
-    //Abstraction of a Shape
-    //    Define abstract class Shape
-    //    Property: Name
-    //    Property: IsFilled
-    //    Abstract Method: GetArea()
-    //    Virtual Method: DisplayArea()
-    //    Method: GetInfo()
-
-    //Define class Circle that inherits from Shape
-    //    Property: Radius
-    //    Override Method: GetArea()
-    //    Override Method: DisplayArea()
 
     public abstract class Shape
     {
-        // Properties
+        // Properties, get set accessors 
         public string Name { get; set; }
         public bool IsFilled { get; set; }
 
         // Abstract method to be implemented by derived classes, no body/implementation here for abstract methods
         public abstract double GetArea();
+
+        // If define here as abstract, must implement in every derived classes
         // public abstract void DisplayArea();
 
+        // Virtual method with a default implementation, can be overridden by derived classes
         public virtual void DisplayArea()
         {
             Console.WriteLine($"Area: {Math.Round(GetArea(), 1)}");
@@ -35,6 +26,7 @@
             Console.WriteLine($"Object: {Name}, Status: {fillStatus}.");
         }
     }
+    // circle class inheriting from Shape class, public to allow access from other classes
     public class Circle : Shape
     {
         // Property specific to Circle


### PR DESCRIPTION
The abstraction principle was applied by introducing a base class Shape with an abstract method GetArea().

A virtual method DisplayArea() was also added. While this could have been abstract, using virtual avoids forcing every derived class to implement it, which would be inefficient and repetitive when the default behavior is sufficient.

The abstract method and polymorphism were demonstrated by creating a Shape reference pointing to a Circle object:

Shape circle = new Circle
{
    Name = "Circle",
    IsFilled = true,
    Radius = 5.0
};
Even though the reference is typed as Shape, we can still set the Radius property because the object initializer is applied before the assignment to the base type. This allows access to derived class properties during initialization.

In contrast, using a Circle reference:

Circle circle1 = new Circle();
circle1.Radius = 5.0;
also works, but this approach doesn't demonstrate abstraction or polymorphism.

-What I Learned
Abstract methods have no body in the base class and must be implemented in derived classes.

Using a base class reference (Shape) to point to a derived object (Circle) allows us to write flexible, reusable code.

Object initializers let us set derived class properties even when assigning to a base class reference — because the actual object is still a Circle during initialization.