### PR TITLE
Add abstract class, and metod and virtual method to the base class

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -4,18 +4,42 @@
     {
         static void Main(string[] args)
         {
-            // Create an instance of Shape
-            Shape shape1 = new Shape();
-            shape1.Name = "Circle";
-            shape1.IsFilled = false;
-            shape1.GetInfo(); // Output: This is a Circle and it Not filled.
+            // Create a Shape reference pointing to a Circle object 
+            // Abstraction and Polymorphism in action
+            Shape circle = new Circle
+            {
+                Name = "Circle",
+                IsFilled = true,
+                Radius = 5.0
+            };
 
-            // create another instance of Shape
-            Shape shape2 = new Shape();
-            shape2.Name = "Rectangle";
-            shape2.IsFilled = true;
-            shape2.GetInfo(); // Output: This is a Rectangle and it is Filled.
+            // Create a shape reference pointing to a Rectangle object
+            Shape rectangle = new Rectangle
+            {
+                Name = "Rectangle",
+                IsFilled = false,
+                Length = 4.0,
+                Width = 6.0
+            };
 
+            // Create a shape reference pointing to a Triangle object
+            Shape triangle = new Triangle
+            {
+                Name = "Triangle",
+                IsFilled = true,
+                Base = 3.0,
+                Height = 4.0
+            };
+            // create an array of shapes to demonstrate polymorphism
+            var shapes = new Shape[] { circle, rectangle, triangle };
+
+            // loop through the array and display info and area for each shape
+            foreach (Shape shape in shapes)
+            {
+                Console.WriteLine("--- New Shape Object ---");
+                shape.GetInfo();
+                shape.DisplayArea();
+            }
         }
     }
 }

--- a/Shape.cs
+++ b/Shape.cs
@@ -1,16 +1,62 @@
 ﻿namespace OOP_Example
 {
-    public class Shape
+
+    public abstract class Shape
     {
-        // Properties
+        // Properties, get set accessors 
         public string Name { get; set; }
         public bool IsFilled { get; set; }
+
+        // Abstract method to be implemented by derived classes, no body/implementation here for abstract methods
+        public abstract double GetArea();
+
+        // If define here as abstract, must implement in every derived classes
+        // public abstract void DisplayArea();
+
+        // Virtual method with a default implementation, can be overridden by derived classes
+        public virtual void DisplayArea()
+        {
+            Console.WriteLine($"Area: {Math.Round(GetArea(), 1)}");
+        }
 
         // Methods
         public void GetInfo()
         {
             string fillStatus = IsFilled ? "Filled" : "Not filled"; //Derived value
-            Console.WriteLine($"This is a {Name} and it is {fillStatus}.");
+            Console.WriteLine($"Object: {Name}, Status: {fillStatus}.");
         }
+    }
+    // circle class inheriting from Shape class, public to allow access from other classes
+    public class Circle : Shape
+    {
+        // Property specific to Circle
+        public double Radius { get; set; }
+
+        // Override the abstract method to provide implementation
+        public override double GetArea()
+        {
+            return Math.PI * Radius * Radius;
+        }
+    }
+    public class Rectangle : Shape
+    {
+        public double Length { get; set; }
+        public double Width { get; set; }
+
+        public override double GetArea()
+        {
+            return Length * Width;
+        }
+
+    }
+    public class Triangle : Shape
+    {
+        public double Base { get; set; }
+        public double Height { get; set; }
+        public override double GetArea()
+        {
+            return 0.5 * Base * Height;
+        }
+
     }
 }


### PR DESCRIPTION
The abstraction principle was applied by introducing a base class Shape with an abstract method GetArea().

A virtual method DisplayArea() was also added. While this could have been abstract, using virtual avoids forcing every derived class to implement it, which would be inefficient and repetitive when the default behavior is sufficient.

The abstract method and polymorphism were demonstrated by creating a Shape reference pointing to a Circle object:

Shape circle = new Circle
{
Name = "Circle",
IsFilled = true,
Radius = 5.0
};
Even though the reference is typed as Shape, we can still set the Radius property because the object initializer is applied before the assignment to the base type. This allows access to derived class properties during initialization.

In contrast, using a Circle reference:

Circle circle1 = new Circle();
circle1.Radius = 5.0;
also works, but this approach doesn't demonstrate abstraction or polymorphism.

-What I Learned
Abstract methods have no body in the base class and must be implemented in derived classes.

Using a base class reference (Shape) to point to a derived object (Circle) allows us to write flexible, reusable code.

Object initializers let us set derived class properties even when assigning to a base class reference — because the actual object is still a 